### PR TITLE
石臼のアイテム変換に関するコードの改良

### DIFF
--- a/src/main/java/net/hayato08/udonmod/procedures/StoneMillItemChangerProcedure.java
+++ b/src/main/java/net/hayato08/udonmod/procedures/StoneMillItemChangerProcedure.java
@@ -12,6 +12,7 @@ import net.minecraft.world.item.Items;
 import java.util.Map;
 import java.util.function.Supplier;
 
+// ボタンが押されたらこのクラスのexecuteメソッドが呼び出される
 public class StoneMillItemChangerProcedure
 {
 	public static void execute(Entity entity)
@@ -20,97 +21,119 @@ public class StoneMillItemChangerProcedure
 			return;
 		double slot0 = 0;
 		double slot1 = 0;
-		if ((entity instanceof Player _plrSlotItem && _plrSlotItem.containerMenu instanceof Supplier _splr && _splr.get() instanceof Map _slt ? ((Slot) _slt.get(0)).getItem() : ItemStack.EMPTY).getItem() == Items.WHEAT)
+
+		// スロット０に小麦が入っているとき
+		if ((entity instanceof Player pPpayerSlotItem && pPpayerSlotItem.containerMenu instanceof Supplier pSupplier &&
+				pSupplier.get() instanceof Map pSlot ? ((Slot) pSlot.get(0)).getItem() : ItemStack.EMPTY).getItem() == Items.WHEAT)
 		{
-			// スロット0にあるアイテムの個数
-			slot0 = new Object()
+			slot0 = getAmount(entity, 0); // スロット0にあるアイテムの個数
+			slot1 = getAmount(entity, 1); // スロット1にあるアイテムの個数
+
+			ItemStack pSetstack = new ItemStack(UdonItems.FLOUR.get()).copy(); // 変換するアイテムを取得
+
+			if(slot1 != 0) //スロット１に何かアイテムがあるとき
 			{
-				public int getAmount(int sltid)
+				// スロット１のアイテムが小麦粉のとき
+				if ((entity instanceof Player pPpayerSlotItem && pPpayerSlotItem.containerMenu instanceof Supplier pSupplier &&
+						pSupplier.get() instanceof Map pSlot ? ((Slot) pSlot.get(1)).getItem() : ItemStack.EMPTY).getItem() == UdonItems.FLOUR.get())
 				{
-					if (entity instanceof Player _player && _player.containerMenu instanceof Supplier _current && _current.get() instanceof Map _slots)
-					{
-						ItemStack stack = ((Slot) _slots.get(sltid)).getItem();
-						if (stack != null)
-							return stack.getCount();
-					}
-					return 0;
+					itemCanger(entity, pSetstack, slot0, slot1);
 				}
-			}.getAmount(0);
-
-			// スロット1にあるアイテムの個数
-			slot1 = new Object()
-			{
-				public int getAmount(int sltid)
-				{
-					if (entity instanceof Player _player && _player.containerMenu instanceof Supplier _current && _current.get() instanceof Map _slots)
-					{
-						ItemStack stack = ((Slot) _slots.get(sltid)).getItem();
-						if (stack != null)
-							return stack.getCount();
-					}
-					return 0;
-				}
-			}.getAmount(1);
-
-			if (slot0 + slot1 <= 64) // スロット０と１の和が64以下の時
-			{
-				if (entity instanceof Player _player) {
-					_player.level().playSound(
-							null,
-							_player.getX(), _player.getY(), _player.getZ(),
-							UdonSounds.STONE_MILL_USE.get(),
-							SoundSource.BLOCKS,
-							1.0F, 1.0F
-					);
-				}
-
-				if (entity instanceof Player _player && _player.containerMenu instanceof Supplier _current && _current.get() instanceof Map _slots)
-				{
-					// スロット０のアイテムを削除
-					((Slot) _slots.get(0)).remove((int) slot0);
-					_player.containerMenu.broadcastChanges();
-				}
-				if (entity instanceof Player _player && _player.containerMenu instanceof Supplier _current && _current.get() instanceof Map _slots)
-				{
-					// スロット０にあった個数分、スロット1に小麦粉を追加
-					ItemStack _setstack = new ItemStack(UdonItems.FLOUR.get()).copy();
-					_setstack.setCount((int) (slot0 + slot1));
-					((Slot) _slots.get(1)).set(_setstack);
-					_player.containerMenu.broadcastChanges();
-				}
-
 			}
-			else if (slot0 + slot1 > 64) //スロット０と１の合計が64個を超える場合
+			else // スロット１にアイテムがないとき
 			{
-				if(slot1 != 64) // スロット０が64でないとき
-				{
-					if (entity instanceof Player _player)
-					{
-						_player.level().playSound(
-								null,
-								_player.getX(), _player.getY(), _player.getZ(),
-								UdonSounds.STONE_MILL_USE.get(),
-								SoundSource.BLOCKS,
-								1.0F, 1.0F
-						);
-					}
-					if (entity instanceof Player _player && _player.containerMenu instanceof Supplier _current && _current.get() instanceof Map _slots)
-					{
-						// スロット１にあるアイテムの個数と64との差分をスロット０から削除
-						((Slot) _slots.get(0)).remove((int) (64 - slot1));
-						_player.containerMenu.broadcastChanges();
-					}
-					if (entity instanceof Player _player && _player.containerMenu instanceof Supplier _current && _current.get() instanceof Map _slots)
-					{
-						// スロット１に64個の小麦粉を追加
-						ItemStack _setstack = new ItemStack(UdonItems.FLOUR.get()).copy();
-						_setstack.setCount(64);
-						((Slot) _slots.get(1)).set(_setstack);
-						_player.containerMenu.broadcastChanges();
-					}
-				}
-
+				// アイテムを変換
+				itemCanger(entity, pSetstack, slot0, slot1);
 			}
 		}
+		// かつお節を削り鰹節にする
+		else if((entity instanceof Player pPlayerSlotItem && pPlayerSlotItem.containerMenu instanceof Supplier pSupplier &&
+				pSupplier.get() instanceof Map pSlot ? ((Slot) pSlot.get(0)).getItem() : ItemStack.EMPTY).getItem() == UdonItems.DRIED_KATSUO.get())
+		{
+			slot0 = getAmount(entity, 0); // スロット0にあるアイテムの個数
+			slot1 = getAmount(entity, 1); // スロット1にあるアイテムの個数
+
+			ItemStack pSetstack = new ItemStack(UdonItems.KATSUO_FLAKES.get()).copy(); // 変換するアイテムを取得
+
+			if(slot1 != 0) //スロット１に何かアイテムがあるとき
+			{
+				// スロット１のアイテムが削り鰹節のとき
+				if ((entity instanceof Player pPpayerSlotItem && pPpayerSlotItem.containerMenu instanceof Supplier pSupplier &&
+						pSupplier.get() instanceof Map pSlot ? ((Slot) pSlot.get(1)).getItem() : ItemStack.EMPTY).getItem() == UdonItems.KATSUO_FLAKES.get())
+				{
+					itemCanger(entity, pSetstack, slot0, slot1);
+				}
+			}
+			else // スロット１にアイテムがないとき
+			{
+				// アイテムを変換
+				itemCanger(entity, pSetstack, slot0, slot1);
+			}
+		}
+	}
+
+	// 石臼使用時の音を再生
+	public static void playStoneMillSound (Player pPlayer)
+	{
+		pPlayer.level().playSound(
+				null,
+				pPlayer.getX(), pPlayer.getY(), pPlayer.getZ(),
+				UdonSounds.STONE_MILL_USE.get(),
+				SoundSource.BLOCKS,
+				1.0F, 1.0F
+		);
+	}
+
+	/*
+	    アイテムを変換するメソッド
+	    第1引数は対象のエンティティ
+	    第2引数は変換後のアイテム
+	    第3、第4引数は各スロットのアイテムの個数
+	    第4引数は2つのスロットの個数の合計値が64を超える場合は真
+	    Usage:
+			<ItemStack pSetstack = new ItemStack(UdonItems.FLOUR.get()).copy();>
+			 itemCanger(entity, pSetstack, slot0, slot1, true);
+	*/
+
+	public static void itemCanger(Entity entity, ItemStack pSetstack, double slot0, double slot1)
+	{
+		if(slot0 + slot1 <= 64)
+		{
+			if (entity instanceof Player pPlayer) {
+				playStoneMillSound(pPlayer);
+			}
+			if (entity instanceof Player pPlayer && pPlayer.containerMenu instanceof Supplier _current && _current.get() instanceof Map pSlots)
+			{
+
+				((Slot) pSlots.get(0)).remove((int) slot0); // スロット０のアイテムを削除
+				pSetstack.setCount((int) (slot0 + slot1)); // スロット０にあった個数分、スロット1にアイテムを追加
+				((Slot) pSlots.get(1)).set(pSetstack);
+				pPlayer.containerMenu.broadcastChanges();
+			}
+		}
+		else if(slot0 + slot1 > 64 && slot1 != 64)
+		{
+			if (entity instanceof Player pPlayer) {
+				playStoneMillSound(pPlayer);
+			}
+			if (entity instanceof Player pPlayer && pPlayer.containerMenu instanceof Supplier _current && _current.get() instanceof Map pSlots)
+			{
+				((Slot) pSlots.get(0)).remove((int) (64 - slot1)); // スロット１にあるアイテムの個数と64との差分をスロット０から削除
+				pSetstack.setCount(64); // スロット１に64個のアイテムを追加
+				((Slot) pSlots.get(1)).set(pSetstack);
+				pPlayer.containerMenu.broadcastChanges();
+			}
+		}
+	}
+	// 各スロットのアイテムの個数を取得
+	public static int getAmount(Entity entity, int slotNo)
+	{
+		if (entity instanceof Player _player && _player.containerMenu instanceof Supplier _current && _current.get() instanceof Map pSlots)
+		{
+			ItemStack stack = ((Slot) pSlots.get(slotNo)).getItem();
+			if (stack != null)
+				return stack.getCount();
+		}
+		return 0;
 	}
 }


### PR DESCRIPTION
StoneMillItemChangerProcedureのソースコードの改良
・スロットの個数を数えるメソッド、アイテム変換に関するメソッド、サウンドを再生するメソッドに独立させて追加
・かつお節を削れるように追加
・スロット１にすでにアイテムがあり、スロット0の変換後のアイテムと整合性がとれない場合に、Millできないように条件分岐
・その他、無駄な条件分岐とメソッドの呼び出しの削除